### PR TITLE
fix: add max-width to mdi-icons

### DIFF
--- a/src/components/CommunityRun.tsx
+++ b/src/components/CommunityRun.tsx
@@ -25,7 +25,7 @@ const CommunityRun = () => {
             </div>
           </div>
           <div className="p-4 order-2 lg:order-1 text-torch-700">
-            <Icon className="lg:ml-36 lg:mr-4 mdi-icon" size={16} path={mdiAccountGroup} />
+            <Icon className="lg:ml-36 lg:mr-4 lg:max-w-7xl mdi-icon" size={16} path={mdiAccountGroup} />
           </div>
         </div>
       </div>

--- a/src/components/CommunityRun.tsx
+++ b/src/components/CommunityRun.tsx
@@ -25,7 +25,7 @@ const CommunityRun = () => {
             </div>
           </div>
           <div className="p-4 order-2 lg:order-1 text-torch-700">
-            <Icon className="lg:ml-36 lg:mr-4" size={16} path={mdiAccountGroup} />
+            <Icon className="lg:ml-36 lg:mr-4 mdi-icon" size={16} path={mdiAccountGroup} />
           </div>
         </div>
       </div>

--- a/src/components/UltimateMediaServer.tsx
+++ b/src/components/UltimateMediaServer.tsx
@@ -8,7 +8,7 @@ const UltimateMediaServer = () => {
       <div className="container mx-auto">
         <div className="flex flex-col lg:flex-row gap-6 mx-4 lg:mx-24 lg:flex-grow-0">
           <div className="p-4 order-1 lg:order-2 text-torch-700">
-            <Icon className="lg:ml-4" size={16} path={mdiServer} />
+            <Icon className="lg:ml-4 mdi-icon" size={16} path={mdiServer} />
           </div>
           <div className="order-2 lg:order-1 lg:max-w-7xl lg:ml-48 flex flex-col items-start justify-center">
             <h2 className="font-black text-5xl mb-6">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,8 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Until https://github.com/levrik/mdi-react/issues/83 has been fixed this seems necessary */
+.mdi-icon {
+    max-width: 100%;
+}


### PR DESCRIPTION
I don't know if this is the fix you'd want, but setting a max-width 100% fixes the overflow issue on smaller screens.

Before
![image](https://user-images.githubusercontent.com/675118/133034810-f06f0510-fcb5-4a79-8cf2-52f3d94dd824.png)

After
![image](https://user-images.githubusercontent.com/675118/133034772-0cd4581a-63bb-4064-a4d7-61946186a0be.png)
